### PR TITLE
Se modifican los branches a los cuales se apunta en el inicializador …

### DIFF
--- a/weeaboo/machines/dotnet.rb
+++ b/weeaboo/machines/dotnet.rb
@@ -104,9 +104,9 @@ end
 class Kaoru < Dot_net
 	def initialize()
 		super(
-			:client_branch => 'main',
-			:opportunities_branch => 'main',
-			:gateway_branch => 'main',
+			:client_branch => 'development',
+			:opportunities_branch => 'development',
+			:gateway_branch => 'development',
 			:login_branch => 'main',
 
 			:service_gateway => 'sigrha_gateway_test',


### PR DESCRIPTION
Se modificaron los branches a los cuales se apunta en el inicializador de Kaoru

```
:client_branch => 'development',
:opportunities_branch => 'development',
:gateway_branch => 'development',
```